### PR TITLE
Adding #include <boost/asio.hpp>.

### DIFF
--- a/src/producer-context.hpp
+++ b/src/producer-context.hpp
@@ -36,6 +36,7 @@
 #include <ndn-cxx/management/nfd-controller.hpp>
 #include <ndn-cxx/util/scheduler.hpp>
 
+#include <boost/asio.hpp>
 #include <boost/thread.hpp>
 #include <boost/lockfree/queue.hpp>
 #include <boost/atomic.hpp>


### PR DESCRIPTION
 Previous version had errors not recognizing asio from boost library.

![consumerproducer_error](https://cloud.githubusercontent.com/assets/11635469/13572618/041f7e56-e45a-11e5-9726-8cdfa96a1297.png)
